### PR TITLE
Connection string dialogue:Add name to each connection string

### DIFF
--- a/PurpleExplorer/Models/ServiceBusConnectionString.cs
+++ b/PurpleExplorer/Models/ServiceBusConnectionString.cs
@@ -4,4 +4,5 @@ public class ServiceBusConnectionString
 {
     public bool UseManagedIdentity { get; set; }
     public string ConnectionString { get; set; }
+    public string Name { get; set; }
 }

--- a/PurpleExplorer/ViewModels/ConnectionStringWindowViewModel.cs
+++ b/PurpleExplorer/ViewModels/ConnectionStringWindowViewModel.cs
@@ -7,10 +7,18 @@ namespace PurpleExplorer.ViewModels;
 
 public class ConnectionStringWindowViewModel : DialogViewModelBase
 {
+    private string _name;
     private string _connectionString;
     private bool _useManagedIdentity;
     private readonly IAppState _appState;
     public ObservableCollection<ServiceBusConnectionString> SavedConnectionStrings { get; set; }
+
+    public string Name
+    {
+        get => _name;
+        set => this.RaiseAndSetIfChanged(ref _name, value);
+    }
+
     public string ConnectionString
     {
         get => _connectionString;

--- a/PurpleExplorer/Views/ConnectionStringWindow.xaml
+++ b/PurpleExplorer/Views/ConnectionStringWindow.xaml
@@ -15,15 +15,20 @@
         <vm:ConnectionStringWindowViewModel />
     </Design.DataContext>
 
-    <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto">
-        <Label Grid.Row="0" Margin="5, 5, 0, 0" VerticalAlignment="Bottom">Connection String:</Label>
-        <TextBox Grid.Row="1" Height="30" Width="600" TextWrapping="Wrap" HorizontalAlignment="Left"
+    <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+        <Label Grid.Row="0" Margin="5, 5, 0, 0" VerticalAlignment="Bottom">Name:</Label>
+        <TextBox Grid.Row="1" Width="200" HorizontalAlignment="Left"
+                 Margin="5, 0, 0, 0"
+                 VerticalAlignment="Top" Text="{CompiledBinding Path=Name, Mode=TwoWay}" />
+
+        <Label Grid.Row="2" Margin="5, 5, 0, 0" VerticalAlignment="Bottom">Connection String:</Label>
+        <TextBox Grid.Row="3" Height="30" Width="600" TextWrapping="Wrap" HorizontalAlignment="Left"
                  Margin="5, 0, 0, 0"
                  VerticalAlignment="Top" Text="{CompiledBinding Path=ConnectionString, Mode=TwoWay}" />
 
-        <CheckBox Grid.Row="2" Margin="5, 3, 0, 0" VerticalAlignment="Top" IsChecked="{CompiledBinding UseManagedIdentity}">Use Managed Identity</CheckBox>
+        <CheckBox Grid.Row="4" Margin="5, 3, 0, 0" VerticalAlignment="Top" IsChecked="{CompiledBinding UseManagedIdentity}">Use Managed Identity</CheckBox>
 
-        <DockPanel Grid.Row="3" Dock="Left" Margin="5, 0, 5, 0">
+        <DockPanel Grid.Row="5" Dock="Left" Margin="5, 0, 5, 0">
             <Button Width="200" Height="30" Margin="0,0,5,0" HorizontalAlignment="Left" VerticalAlignment="Top"
                     IsEnabled="{CompiledBinding ConnectionString, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
                     Click="btnSaveConnectionString">
@@ -44,21 +49,17 @@
             </StackPanel>
         </DockPanel>
 
-        <ListBox Grid.Row="4" Name="lsbSavedConnectionString" Margin="5,0,5,0"
-                 Items="{Binding Path=SavedConnectionStrings, Mode=TwoWay}"
-                 Width="600" Height="300" VerticalAlignment="Top"
-                 SelectionChanged="lsbConnectionStringSelectionChanged" HorizontalAlignment="Left">
-
-            <ListBox.ItemTemplate>
-                <DataTemplate>
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="{Binding ConnectionString}" />
-                        <TextBlock Text="[Managed Identity]" IsVisible="{Binding UseManagedIdentity}" Margin="5,0,0,0" />
-                    </StackPanel>
-                </DataTemplate>
-            </ListBox.ItemTemplate>
-        </ListBox>
-        <Button Grid.Row="5" Width="200" Height="30" Margin="5,0,5,0" HorizontalAlignment="Left"
+        <DataGrid Grid.Row="6" Name="lsbSavedConnectionString" Margin="5, 0, 5, 0"
+                  Items="{Binding Path=SavedConnectionStrings, Mode=TwoWay}"
+                  Height="300"
+                  SelectionChanged="lsbConnectionStringSelectionChanged">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Name" Binding="{Binding Name}"/>
+                <DataGridCheckBoxColumn Header="MI" Binding="{Binding UseManagedIdentity}"/>
+                <DataGridTextColumn Header="Connection String" Binding="{Binding ConnectionString}"/>
+            </DataGrid.Columns>
+        </DataGrid>
+        <Button Grid.Row="7" Width="200" Height="30" Margin="5,0,5,0" HorizontalAlignment="Left"
                 IsEnabled="{Binding #lsbSavedConnectionString.SelectedItem, Converter={x:Static ObjectConverters.IsNotNull}}"
                 VerticalAlignment="Top"
                 HotKey="Escape"

--- a/PurpleExplorer/Views/ConnectionStringWindow.xaml.cs
+++ b/PurpleExplorer/Views/ConnectionStringWindow.xaml.cs
@@ -43,6 +43,7 @@ public class ConnectionStringWindow : Window
         else
             dataContext.SavedConnectionStrings.Add(new Models.ServiceBusConnectionString
             {
+                Name = dataContext.Name,
                 ConnectionString = dataContext.ConnectionString,
                 UseManagedIdentity = dataContext.UseManagedIdentity
             });
@@ -50,18 +51,19 @@ public class ConnectionStringWindow : Window
 
     private void lsbConnectionStringSelectionChanged(object sender, SelectionChangedEventArgs e)
     {
-        var box = sender as ListBox;
+        var dataGrid = sender as DataGrid;
         var dataContext = DataContext as ConnectionStringWindowViewModel;
-        var serviceBusConnectionString = box.SelectedItem as Models.ServiceBusConnectionString;
-        dataContext.ConnectionString = serviceBusConnectionString.ConnectionString;
-        dataContext.UseManagedIdentity = serviceBusConnectionString.UseManagedIdentity;
+        var item = dataGrid.SelectedItem as Models.ServiceBusConnectionString;
+        dataContext.Name = item.Name;
+        dataContext.ConnectionString = item.ConnectionString;
+        dataContext.UseManagedIdentity = item.UseManagedIdentity;
     }
 
     public void btnDeleteConnectionString(object sender, RoutedEventArgs e)
     {
         var dataContext = DataContext as ConnectionStringWindowViewModel;
-        var listBox = this.FindControl<ListBox>("lsbSavedConnectionString");
-        dataContext.SavedConnectionStrings.Remove(listBox.SelectedItem as Models.ServiceBusConnectionString);
+        var dataGrid = this.FindControl<DataGrid>("lsbSavedConnectionString");
+        dataContext.SavedConnectionStrings.Remove(dataGrid.SelectedItem as Models.ServiceBusConnectionString);
     }
     
     public void OnCancel(object? sender, RoutedEventArgs args)


### PR DESCRIPTION
This commit adds Name to the connection string class so it now contains Name, Connection string and Use managed identity. The purpose of this is to easier find the correct connection should one have many.

The list of connection strings is editable.

The rest of the functionality for the dialogue is kept as is.