### PR TITLE
MainWindow:Open dialogue can be opened with a shortcut (cmd-o)

### DIFF
--- a/PurpleExplorer/Views/MainWindow.xaml
+++ b/PurpleExplorer/Views/MainWindow.xaml
@@ -22,10 +22,13 @@
         </Grid.RowDefinitions>
         <DockPanel Grid.Column="0" Grid.Row="0" Dock="Left" Background="#380f14">
             <Button HorizontalAlignment="Left" Command="{Binding ConnectionBtnPopupCommand}"
+                    HotKey="Meta+O"
                     Classes="topButton">
                 <StackPanel Orientation="Horizontal">
                     <i:Icon Value="fa-plug" />
-                    <TextBlock VerticalAlignment="Center">Connect</TextBlock>
+                    <TextBlock VerticalAlignment="Center">C</TextBlock>
+                    <TextBlock VerticalAlignment="Center" FontWeight="Bold" FontStyle="Italic">o</TextBlock>
+                    <TextBlock VerticalAlignment="Center">nnect</TextBlock>
                 </StackPanel>
             </Button>
             <Button Name="RefreshButton" Classes="topButton" IsEnabled="{Binding QueueLevelActionEnabled^}"


### PR DESCRIPTION
This commmit adds a shortcut so the open connection dialogue can be opened with cmd-O. This is a pain in the Windows world as cmd(win) button is used for system events, and not per application. Instead ctrl should be used. But as I am, presently, the sole user of this fork I choose to not solve the problem. Right now.

This commit also introduced the graphical cue that text in italic is a shortcut. Again - the standard is different in Windows with an underlined letter. But then - again - I choose to not solve the problem. Now.

This commit solves #6