### PR TITLE
MainWindow:Move Opendialogue openint to correct method

### DIFF
--- a/PurpleExplorer/Views/MainWindow.xaml.cs
+++ b/PurpleExplorer/Views/MainWindow.xaml.cs
@@ -24,12 +24,12 @@ public class MainWindow : Window
     {
         AvaloniaXamlLoader.Load(this);
     }
-
-    public override async void Show()
+    
+    protected override async void OnOpened(EventArgs e)
     {
-        base.Show();
         var appState = Locator.Current.GetService<IAppState>() as AppState ?? throw new Exception("Unknown AppState");
         await ModalWindowHelper.ShowModalWindow<ConnectionStringWindow>(appState);
+        base.OnOpened(e);
     }
 
     private async void MessagesGrid_DoubleTapped(object sender, RoutedEventArgs e)


### PR DESCRIPTION
As I am not sure of which method to use I can only trial and horror.

This commit is a bug fix. Supposedly fixing an issue where I opened the OpenDialogue two times.

This commit solves #16. Hopefully.