### PR TITLE
SettingsDlg:Set focus on control when opening

### DIFF
--- a/PurpleExplorer/Views/AppSettingsWindow.axaml
+++ b/PurpleExplorer/Views/AppSettingsWindow.axaml
@@ -29,8 +29,8 @@
         
         <Grid ColumnDefinitions="250,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto"  Margin="4" VerticalAlignment="Top">
                 <TextBlock Text="How many queues to fetch from namespace" Grid.Row="0" Grid.Column="0" Classes="left"/>
-                <NumericUpDown Grid.Row="0" Grid.Column="1" Value="{Binding AppSettings.QueueListFetchCount}" Classes="right" />
-                
+                <NumericUpDown Name="QueueListFetchCount" Grid.Row="0" Grid.Column="1" Value="{Binding AppSettings.QueueListFetchCount}" Classes="right" />
+
                 <TextBlock Text="How many messages to fetch from queue" Grid.Row="1" Grid.Column="0" Classes="left"/>
                 <NumericUpDown Grid.Row="1" Grid.Column="1" Value="{Binding AppSettings.QueueMessageFetchCount}" Classes="right" />
                 

--- a/PurpleExplorer/Views/AppSettingsWindow.axaml.cs
+++ b/PurpleExplorer/Views/AppSettingsWindow.axaml.cs
@@ -1,5 +1,7 @@
+using System;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
 
@@ -18,10 +20,35 @@ public partial class AppSettingsWindow : Window
     private void InitializeComponent()
     {
         AvaloniaXamlLoader.Load(this);
+
+        // Even though we do as we do in ConnectionStringWindow it does not work to set focus.
+        // See https://stackoverflow.com/questions/7050559/how-to-set-focus-on-numericupdown-control
+        var ctrl = this.FindControl<NumericUpDown>("QueueListFetchCount")
+                   ?? throw new Exception("Control not found.");
+        SetFocus(ctrl);
     }
-    
+
     public void OnClose(object? sender, RoutedEventArgs args)
     {
         this.Close();
+    }
+    /// <summary>This method sets the focus to the control at start time.
+    /// I would prefer to do it *in xaml*,
+    /// like in this issue: <see cref="https://github.com/AvaloniaUI/Avalonia/issues/4835#issuecomment-707590940"/>
+    /// but I cannot get the code to work.
+    /// I added
+    /// "Avalonia.Xaml.Behaviors" Version="11.0.2"
+    /// "Avalonia.Xaml.Interactions" Version="11.0.2"
+    /// "Avalonia.Xaml.Interactions.Responsive" Version="11.0.2"
+    /// "Avalonia.Xaml.Interactivity" Version="11.0.2"
+    /// and updated the xaml as the link says; but to no avail.
+    ///
+    /// I keep this information here for future me, or someone else, to stumble over and implement.
+    /// </summary>
+    /// <param name="ctrl"></param>
+    private static void SetFocus(InputElement ctrl)
+    {
+        ctrl.Focusable = true;
+        ctrl.AttachedToVisualTree += (_,_) => ctrl.Focus();
     }
 }


### PR DESCRIPTION
This commit sets focus on the first control when the settings dialogue opens. Strangely enougth it does not work.
Also strangely is that choose to keep code that does not work. But I have seen stranger things.