### PR TITLE
ConnectionsStringWindow:Open connection when user presses enter

### DIFF
--- a/PurpleExplorer/Views/ConnectionStringWindow.xaml
+++ b/PurpleExplorer/Views/ConnectionStringWindow.xaml
@@ -41,6 +41,7 @@
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
                 <Button Width="200" Height="30" Margin="0,0,0,0" HorizontalAlignment="Right" VerticalAlignment="Top"
                         IsEnabled="{CompiledBinding ConnectionString, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                        IsDefault="True"
                         Click="btnConnectClick">
                     <StackPanel Orientation="Horizontal" Spacing="5">
                         <i:Icon Value="fa-plug" />


### PR DESCRIPTION
This commit changes the behaviour so that the Connect-button is default. This means that entering a connection string and then pressing enter connects to the message bus service.