### PR TITLE
MessageDialogue:Add shortcut to close

### DIFF
--- a/PurpleExplorer/Views/ConnectionStringWindow.xaml
+++ b/PurpleExplorer/Views/ConnectionStringWindow.xaml
@@ -75,8 +75,15 @@
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
                 <Button Click="OnClose" IsCancel="True"
                         Width="200"
-                        Content="Close" 
-                        HotKey="Escape">
+                        HotKey="Meta+W">
+                    <StackPanel Orientation="Horizontal" Spacing="5">
+                            <i:Icon Value="fa-times"/>
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock VerticalAlignment="Center">C</TextBlock>
+                            <TextBlock VerticalAlignment="Center" FontWeight="Bold" FontStyle="Italic">w</TextBlock>
+                            <TextBlock VerticalAlignment="Center">ose</TextBlock>
+                        </StackPanel>
+                    </StackPanel>
                 </Button>
             </StackPanel>
         </DockPanel>

--- a/PurpleExplorer/Views/MessageDetailsWindow.xaml
+++ b/PurpleExplorer/Views/MessageDetailsWindow.xaml
@@ -68,11 +68,13 @@
                     </StackPanel>
                 </Button>
                 <Button Click="OnClose" IsCancel="True"
-                        DockPanel.Dock="Right" HotKey="Escape"
+                        DockPanel.Dock="Right" HotKey="Meta+W"
                         Classes="topButton">
                     <StackPanel Orientation="Horizontal">
-                        <i:Icon Value="fa-window-close"/>
-                        <TextBlock VerticalAlignment="Center">Close</TextBlock>
+                        <i:Icon Value="fa-times"/>
+                        <TextBlock VerticalAlignment="Center">C</TextBlock>
+                        <TextBlock VerticalAlignment="Center" FontWeight="Bold" FontStyle="Italic">w</TextBlock>
+                        <TextBlock VerticalAlignment="Center">ose</TextBlock>
                     </StackPanel>
                 </Button>
             </DockPanel>

--- a/PurpleExplorer/Views/MessageDetailsWindow.xaml.cs
+++ b/PurpleExplorer/Views/MessageDetailsWindow.xaml.cs
@@ -20,7 +20,7 @@ public class MessageDetailsWindow : Window
         AvaloniaXamlLoader.Load(this);
     }
 
-    private void OnClose(object? sender, RoutedEventArgs e)
+    public void OnClose(object? sender, RoutedEventArgs e)
     {
         Close();
     }


### PR DESCRIPTION
This commit adds both Esc and meta-W as shortcuts
to close the message dialogue.
Too bad it does not work. The same code
as for the connection string dialogue,
that does work. Strange.